### PR TITLE
Add iOS MVP example

### DIFF
--- a/ios-mvp/App/ContentView.swift
+++ b/ios-mvp/App/ContentView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import NetworkExtension
+
+struct ContentView: View {
+    @State private var isOn = false
+
+    var body: some View {
+        VStack {
+            Toggle(isOn: $isOn) {
+                Text(isOn ? "Disconnect" : "Connect")
+            }
+            .padding()
+            .onChange(of: isOn) { value in
+                if value {
+                    startTunnel()
+                } else {
+                    stopTunnel()
+                }
+            }
+        }
+    }
+
+    private func startTunnel() {
+        let manager = NETunnelProviderManager.shared()
+        manager.loadFromPreferences { error in
+            guard error == nil else { return }
+            manager.connection.startVPNTunnel()
+        }
+    }
+
+    private func stopTunnel() {
+        let manager = NETunnelProviderManager.shared()
+        manager.connection.stopVPNTunnel()
+    }
+}

--- a/ios-mvp/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios-mvp/PacketTunnel/PacketTunnelProvider.swift
@@ -1,0 +1,42 @@
+import NetworkExtension
+
+class PacketTunnelProvider: NEPacketTunnelProvider {
+    private var isRunning = false
+
+    override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
+        guard let configPath = (protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["configPath"] as? String,
+              let datDir = (protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["datDir"] as? String else {
+            completionHandler(NSError(domain: "LibXray", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing configuration"]))
+            return
+        }
+
+        let request: [String: String] = [
+            "datDir": datDir,
+            "configPath": configPath
+        ]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: request),
+              let base64 = jsonData.base64EncodedString().cString(using: .utf8) else {
+            completionHandler(NSError(domain: "LibXray", code: -2, userInfo: [NSLocalizedDescriptionKey: "Invalid request"]))
+            return
+        }
+
+        if let resultPtr = CGoRunXray(base64) {
+            let result = String(cString: resultPtr)
+            // handle error if needed
+            _ = result
+        }
+        isRunning = true
+        completionHandler(nil)
+    }
+
+    override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        if isRunning {
+            if let resultPtr = CGoStopXray() {
+                let result = String(cString: resultPtr)
+                _ = result
+            }
+            isRunning = false
+        }
+        completionHandler()
+    }
+}

--- a/ios-mvp/README.md
+++ b/ios-mvp/README.md
@@ -1,0 +1,30 @@
+# libXray iOS MVP
+
+This folder contains a very small example of how to use `libXray` in an iOS
+project. The goal is to replicate Outline's behaviour using the wrapper
+functions provided by this repository.
+
+## Building `LibXray.xcframework`
+
+1. Install Go and Xcode command line tools.
+2. Run the build script from the repository root:
+
+```bash
+python3 build/main.py apple go
+```
+
+This will create `LibXray.xcframework` along with C header files inside the
+`build/apple` directory. Because the framework does not contain a
+`module.modulemap`, Swift projects need a bridging header.
+
+## Integrating in Xcode
+
+1. Add `LibXray.xcframework` to your Xcode project.
+2. Create a bridging header and include `XrayBridge.h` from this folder.
+3. Add the `PacketTunnelProvider.swift` file to a Network Extension target and
+   use `ContentView.swift` for a very simple UI in the main app target.
+4. Provide two keys in `providerConfiguration` when starting the tunnel:
+   `datDir` (path to geodata) and `configPath` (path to the Xray JSON config).
+
+With these pieces in place you can call `CGoRunXray` and `CGoStopXray` from your
+Swift code to manage the VPN tunnel.

--- a/ios-mvp/XrayBridge.h
+++ b/ios-mvp/XrayBridge.h
@@ -1,0 +1,27 @@
+#ifndef XRAY_BRIDGE_H
+#define XRAY_BRIDGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char* CGoInitDns(const char* base64Text);
+char* CGoResetDns(void);
+char* CGoGetFreePorts(int count);
+char* CGoConvertShareLinksToXrayJson(const char* base64Text);
+char* CGOConvertXrayJsonToShareLinks(const char* base64Text);
+char* CGoCountGeoData(const char* base64Text);
+char* CGoThinGeoData(const char* base64Text);
+char* CGoReadGeoFiles(const char* base64Text);
+char* CGoPing(const char* base64Text);
+char* CGoQueryStats(const char* base64Text);
+char* CGoTestXray(const char* base64Text);
+char* CGoRunXray(const char* base64Text);
+char* CGoStopXray(void);
+char* CGoXrayVersion(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XRAY_BRIDGE_H */


### PR DESCRIPTION
## Summary
- add `ios-mvp` folder with Swift/Objective‑C example
- provide bridging header for libXray C functions
- sample packet tunnel provider and tiny SwiftUI interface
- document how to build and integrate `LibXray.xcframework`

## Testing
- `go test ./...` *(fails: no route to host)*