### PR TITLE
Add macOS build script and sample app

### DIFF
--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Build LibXray and the sample MVP application on macOS.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+# Step 1: Build LibXray xcframework
+python3 "$REPO_ROOT/build/main.py" apple go
+
+# Step 2: Build the Swift MVP example
+pushd "$REPO_ROOT/ios-mvp/MvpApp" >/dev/null
+swift build -c release
+popd >/dev/null
+
+echo "\nBuild completed. The executable can be found at ios-mvp/MvpApp/.build/release/MvpApp"
+

--- a/ios-mvp/MvpApp/CBridge/include/XrayBridge.h
+++ b/ios-mvp/MvpApp/CBridge/include/XrayBridge.h
@@ -1,0 +1,27 @@
+#ifndef XRAY_BRIDGE_H
+#define XRAY_BRIDGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char* CGoInitDns(const char* base64Text);
+char* CGoResetDns(void);
+char* CGoGetFreePorts(int count);
+char* CGoConvertShareLinksToXrayJson(const char* base64Text);
+char* CGOConvertXrayJsonToShareLinks(const char* base64Text);
+char* CGoCountGeoData(const char* base64Text);
+char* CGoThinGeoData(const char* base64Text);
+char* CGoReadGeoFiles(const char* base64Text);
+char* CGoPing(const char* base64Text);
+char* CGoQueryStats(const char* base64Text);
+char* CGoTestXray(const char* base64Text);
+char* CGoRunXray(const char* base64Text);
+char* CGoStopXray(void);
+char* CGoXrayVersion(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XRAY_BRIDGE_H */

--- a/ios-mvp/MvpApp/Package.swift
+++ b/ios-mvp/MvpApp/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "MvpApp",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(name: "MvpApp", targets: ["MvpApp"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "LibXray",
+            path: "../../LibXray.xcframework"
+        ),
+        .target(
+            name: "CBridge",
+            dependencies: ["LibXray"],
+            path: "CBridge",
+            publicHeadersPath: "include"
+        ),
+        .executableTarget(
+            name: "MvpApp",
+            dependencies: ["CBridge"],
+            path: "Sources/MvpApp",
+            linkerSettings: [
+                .linkedFramework("NetworkExtension"),
+                .linkedLibrary("resolv")
+            ]
+        )
+    ]
+)

--- a/ios-mvp/MvpApp/Sources/MvpApp/main.swift
+++ b/ios-mvp/MvpApp/Sources/MvpApp/main.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CBridge
+
+if let ptr = CGoXrayVersion() {
+    let version = String(cString: ptr)
+    print("Xray version: \(version)")
+}

--- a/ios-mvp/README.md
+++ b/ios-mvp/README.md
@@ -13,6 +13,13 @@ functions provided by this repository.
 python3 build/main.py apple go
 ```
 
+This repository also provides a convenience script that builds the framework and
+compiles a tiny command line example on macOS:
+
+```bash
+./build_macos.sh
+```
+
 This will create `LibXray.xcframework` along with C header files inside the
 `build/apple` directory. Because the framework does not contain a
 `module.modulemap`, Swift projects need a bridging header.


### PR DESCRIPTION
## Summary
- add `build_macos.sh` script to compile LibXray and build an example Swift app
- provide Swift Package with simple example in `ios-mvp/MvpApp`
- document the new script in iOS MVP README
- link against `libresolv` to resolve missing symbols on macOS

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*